### PR TITLE
feat: Deploy based on diff

### DIFF
--- a/config/publish.yml
+++ b/config/publish.yml
@@ -1,0 +1,38 @@
+name: Publish ctfup
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+
+      - run: git fetch --all --tags
+        
+      - name: Check version change
+        uses: thebongy/version-check@v1
+        id: check
+        with:
+          file: package.json
+          failBuild: false
+          tagFormat: v${version}
+      
+      - name: Echo variables
+        run: |
+          echo "versionChanged- ${{steps.check.outputs.versionChanged}}"
+          echo "releaseVersion- ${{steps.check.outputs.releaseVersion}}"
+
+      - if: steps.check.outputs.versionChanged == 'true'
+        run: npm install
+
+      - if: steps.check.outputs.versionChanged == 'true'
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_PUBLISH_TOKEN}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ctfup",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/challenges.ts
+++ b/src/challenges.ts
@@ -26,7 +26,7 @@ export class Challenges {
         await Promise.all(categories.map(async (c) => {
             const categoryFolder = path.join(dir, c);
             logger.debug(`Parsing category ${categoryFolder}`);
-            
+
             await Promise.all(
                 (await fs.readdir(categoryFolder)).map(async (folder) => {
                     const challengeFolder = path.join(categoryFolder, folder);
@@ -36,17 +36,17 @@ export class Challenges {
                             if (modifiedChallenges.filter((chall) => chall.includes(challengeFolder)).length) {
                                 logger.debug(`Parsing challenge ${folder}`);
                                 challengePromises.push(
-                                    Challenge.parse(challengeFolder)
+                                    Challenge.parse(challengeFolder),
                                 );
                             }
                         } else {
                             logger.debug(`Parsing challenge ${folder}`);
                             challengePromises.push(
-                                Challenge.parse(challengeFolder)
+                                Challenge.parse(challengeFolder),
                             );
                         }
                     }
-                })
+                }),
             );
         }));
 

--- a/src/challenges.ts
+++ b/src/challenges.ts
@@ -1,9 +1,13 @@
 import fs from 'fs-extra';
 import path from 'path';
 
-import {Challenge} from './challenge';
+import { Challenge } from './challenge';
+import { diff } from './command';
 import logger from './logger';
 
+interface Options {
+    diff: string;
+}
 
 export class Challenges {
     challenges: Challenge[];
@@ -11,19 +15,36 @@ export class Challenges {
         this.challenges = challenges;
     }
 
-    static async parse(dir: string, categories: string[]) {
+    static async parse(dir: string, categories: string[], options?: Options) {
         let challengePromises: Promise<Challenge>[] = [];
+
+        let modifiedChallenges: Array<string> = [];
+        if (options && options.diff) {
+            modifiedChallenges = await diff(options.diff);
+        }
+
         await Promise.all(categories.map(async (c) => {
             const categoryFolder = path.join(dir, c);
             logger.debug(`Parsing category ${categoryFolder}`);
+            
             await Promise.all(
                 (await fs.readdir(categoryFolder)).map(async (folder) => {
                     const challengeFolder = path.join(categoryFolder, folder);
+
                     if ((await fs.stat(challengeFolder)).isDirectory()) {
-                        logger.debug(`Parsing challenge ${folder}`);
-                        challengePromises.push(
-                            Challenge.parse(challengeFolder)
-                        );
+                        if (options && options.diff && modifiedChallenges.length) {
+                            if (modifiedChallenges.filter((chall) => chall.includes(challengeFolder)).length) {
+                                logger.debug(`Parsing challenge ${folder}`);
+                                challengePromises.push(
+                                    Challenge.parse(challengeFolder)
+                                );
+                            }
+                        } else {
+                            logger.debug(`Parsing challenge ${folder}`);
+                            challengePromises.push(
+                                Challenge.parse(challengeFolder)
+                            );
+                        }
                     }
                 })
             );

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,4 +1,4 @@
-import {spawn} from 'child_process';
+import { spawn, exec } from 'child_process';
 import logger from './logger';
 
 
@@ -25,3 +25,17 @@ export async function runCommand(command: string, args: string[]) {
     });
 }
 
+export function diff(commitHash: string) {
+    return new Promise((resolve, reject) => {
+        exec(`git diff --dirstat=files,0 ${commitHash} | sed 's/^[ 0-9.]\\+% //g'`, (error, stdout) => {
+            if (error) {
+                reject(error);
+                return;
+            }
+            resolve(stdout.split('\n').filter((line) => {
+                const trimmedLine = line.trim();
+                if (trimmedLine) return trimmedLine;
+            }));
+        });
+    });
+}

--- a/src/command.ts
+++ b/src/command.ts
@@ -32,10 +32,7 @@ export function diff(commitHash: string) {
                 reject(error);
                 return;
             }
-            resolve(stdout.split('\n').filter((line) => {
-                const trimmedLine = line.trim();
-                if (trimmedLine) return trimmedLine;
-            }));
+            resolve(stdout.trim().split('\n').map((line) => line.trim().slice(0, -1)));
         });
     });
 }

--- a/src/command.ts
+++ b/src/command.ts
@@ -25,12 +25,15 @@ export async function runCommand(command: string, args: string[]) {
     });
 }
 
-export function diff(commitHash: string) {
+export function diff(commitHash: string): Promise<Array<string>> {
     return new Promise((resolve, reject) => {
-        exec(`git diff --dirstat=files,0 ${commitHash} | sed 's/^[ 0-9.]\\+% //g'`, (error, stdout) => {
+        exec(`git diff --dirstat=files,0 ${commitHash} | sed 's/^[ 0-9.]\\+% //g'`, (error, stdout, stderr) => {
             if (error) {
                 reject(error);
                 return;
+            }
+            if (stderr) {
+                logger.error(stderr);
             }
             resolve(stdout.trim().split('\n').map((line) => line.trim().slice(0, -1)));
         });

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ async function main() {
         .version('0.0.1')
         .arguments('[dir]')
         .requiredOption('-c, --config <config>', 'deployment configuration')
+        .option('-d, --diff <commit-id>', 'deploy challenges which were changed from the specified commit-hash')
         .action((arg) => {
             dir = arg;
         });
@@ -27,8 +28,9 @@ async function main() {
     await parseConfig(program.config);
 
     const config = getConfig();
-    const challenges = await Challenges.parse(dir, config.categories);
-   
+    const options = { diff: program.diff };
+    const challenges = await Challenges.parse(dir, config.categories, options);
+    console.log(challenges);
     const deployer = new Deployer();
     for (const challenge of challenges.challenges) {
         if (challenge.type === 'hosted') {
@@ -37,6 +39,5 @@ async function main() {
         }
     }
 }
-
 
 main();


### PR DESCRIPTION
- Added flag `--diff`, which takes a commit-id. Only challenges that were changed since that commit-id are deployed.
- npm publish action added.