### PR TITLE
feat: Add namespace option

### DIFF
--- a/config/deployment.yml
+++ b/config/deployment.yml
@@ -1,7 +1,18 @@
+{{#if namespace}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{namespace}}
+---
+{{/if}}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{name}}
+  {{#if namespace}}
+  namespace: {{namespace}}
+  {{/if}}
   labels:
     category: {{category}}
     challenge: {{name}}
@@ -55,6 +66,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{name}}
+  {{#if namespace}}
+  namespace: {{namespace}}
+  {{/if}}
   labels:
     category: {{category}}
     challenge: {{name}}

--- a/src/challenge.ts
+++ b/src/challenge.ts
@@ -23,6 +23,7 @@ interface Conf {
     expose?: PortMapping[];
     containers?: { [name: string]: Container };
     replicas?: number;
+    namespace?: string;
 }
 
 type ChallengeType = 'hosted' | 'non-hosted';
@@ -45,7 +46,7 @@ export class Challenge {
         let type: ChallengeType;
         let conf: Conf;
 
-        const defaults = getConfig().resources;
+        const defaults = getConfig();
 
         if (await fs.pathExists(ymlPath)) {
             conf = yaml.parse(await fs.readFile(ymlPath, 'utf8')) as Conf;
@@ -53,9 +54,12 @@ export class Challenge {
                 type = 'hosted';
                 for (const name in conf.containers) {
                     const container = conf.containers[name];
-                    if (!container.resources && defaults) {
-                        container.resources = defaults;
+                    if (!container.resources && defaults.resources) {
+                        container.resources = defaults.resources;
                     }
+                }
+                if (!conf.namespace && defaults.namespace) {
+                    conf.namespace = defaults.namespace;
                 }
             } else {
                 type = 'non-hosted';

--- a/src/challenge.ts
+++ b/src/challenge.ts
@@ -50,6 +50,8 @@ export class Challenge {
 
         if (await fs.pathExists(ymlPath)) {
             conf = yaml.parse(await fs.readFile(ymlPath, 'utf8')) as Conf;
+            conf.name = path.basename(dir);
+            conf.category = path.basename(path.dirname(dir));
             if (conf.containers) {
                 type = 'hosted';
                 for (const name in conf.containers) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,7 @@ interface Config {
     registry: string;
     categories: string[];
     resources?: ResourceConstraints;
+    namespace?: string;
 }
 
 let config: Config = {


### PR DESCRIPTION
Sometimes it is useful to use a namespace other than the default one, to group some challenges or even all together. 
With this new feature, it is possible to specify a namespace in `ctfup.yml` or `challenge.yml` for a specific challenge.
If the namespace doesn't exist it will be created thanks to the deployment YAML file.