### PR TITLE
feat: allow choice of namespace

### DIFF
--- a/config/deployment.yml
+++ b/config/deployment.yml
@@ -1,7 +1,18 @@
+{{#if namespace}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{namespace}}
+---
+{{/if}}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{name}}
+  {{#if namespace}}
+  namespace: {{namespace}}
+  {{/if}}
   labels:
     category: {{category}}
     challenge: {{name}}
@@ -55,6 +66,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{name}}
+  {{#if namespace}}
+  namespace: {{namespace}}
+  {{/if}}
   labels:
     category: {{category}}
     challenge: {{name}}

--- a/src/challenge.ts
+++ b/src/challenge.ts
@@ -23,6 +23,7 @@ interface Conf {
     expose?: PortMapping[];
     containers?: { [name: string]: Container };
     replicas?: number;
+    namespace?: string;
 }
 
 type ChallengeType = 'hosted' | 'non-hosted';
@@ -45,7 +46,7 @@ export class Challenge {
         let type: ChallengeType;
         let conf: Conf;
 
-        const defaults = getConfig().resources;
+        const defaults = getConfig();
 
         if (await fs.pathExists(ymlPath)) {
             conf = yaml.parse(await fs.readFile(ymlPath, 'utf8')) as Conf;
@@ -53,9 +54,12 @@ export class Challenge {
                 type = 'hosted';
                 for (const name in conf.containers) {
                     const container = conf.containers[name];
-                    if (!container.resources && defaults) {
-                        container.resources = defaults;
+                    if (!container.resources && defaults.resources) {
+                        container.resources = defaults.resources;
                     }
+                }
+                if (!conf.namespace && defaults.namespace) {
+                    conf.namespace = defaults.namespace;
                 }
             } else {
                 type = 'non-hosted';

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,7 @@ interface Config {
     registry: string;
     categories: string[];
     resources?: ResourceConstraints;
+    namespace?: string;
 }
 
 let config: Config = {


### PR DESCRIPTION
Sometimes it is useful to assign the challenges to a namespace.
With this changes it is possible to define a default one in ctfup.yml or to assign a namespace to a single challenge in challenge.yml