### PR TITLE
feat: Get deployment name from path

### DIFF
--- a/src/challenge.ts
+++ b/src/challenge.ts
@@ -49,6 +49,8 @@ export class Challenge {
 
         if (await fs.pathExists(ymlPath)) {
             conf = yaml.parse(await fs.readFile(ymlPath, 'utf8')) as Conf;
+            conf.name = path.basename(dir);
+            conf.category = path.basename(path.dirname(dir));
             if (conf.containers) {
                 type = 'hosted';
                 for (const name in conf.containers) {

--- a/src/challenge.ts
+++ b/src/challenge.ts
@@ -41,6 +41,14 @@ export class Challenge {
     }
 
     static async parse(dir: string) {
+        // The challenge folder name is sent to Kubernetes for a label
+        // It has to start with a letter and contain only letter, numbers and dashes
+        if (!path.basename(dir).match(/^[a-zA-Z][A-Za-z0-9_-]+$/)) {
+            logger.error('The challenge folder name must start with a letter and can only contain letters, numbers and dashes');
+            logger.error(`"${dir}" not valid`);
+            process.exit(1);
+        }
+
         const ymlPath = path.join(dir, 'challenge.yml');
         let type: ChallengeType;
         let conf: Conf;

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,16 @@ async function main() {
     await parseConfig(program.config);
     const config = getConfig();
 
+    // The category folder name is sent to Kubernetes for a label
+    // It has to start with a letter and contain only letter, numbers and dashes
+    for (const category of config.categories) {
+        if (!category.match(/^[a-zA-Z][A-Za-z0-9_-]+$/)) {
+            logger.error('The category folder name must start with a letter and can only contain letters, numbers and dashes');
+            logger.error(`"${category}" not valid`);
+            process.exit(1);
+        }
+    }
+
     const challenges = await Challenges.parse(dir, config.categories, options);
 
     logger.debug(challenges);


### PR DESCRIPTION
I noticed that if the challenge's name contains a space the deployment fails. That's because Kubernetes allows only letters, numbers and some special characters for the deployment name.
With this commit, ctfup will get category and name from the challenge's path, which is usually just made up of letters, numbers and dashes.