### PR TITLE
targetPort assigns container port!

### DIFF
--- a/config/deployment.yml
+++ b/config/deployment.yml
@@ -81,7 +81,7 @@ spec:
     {{#each expose}}
     - port: {{containerPort}}
       name: port-{{containerPort}}
-      targetPort: {{containerPort}}
+      targetPort: {{targetPort}}
       nodePort: {{nodePort}}
     {{/each}}
 {{/if}}


### PR DESCRIPTION
The targetPort is assigning containerPort. So defining targetPort explicitly doesn't work!